### PR TITLE
Rebuild against llvmdev20

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 3c4f6b10ff6ee950d0ec6ea733cc6e6d34c569454e3d39a9b276de9115a3b363
 
 build:
-  number: 1
+  number: 2
   skip: true  # [win]
   track_features:
     - mesalib
@@ -40,7 +40,7 @@ requirements:
     - zlib {{ zlib }}
     - zstd {{ zstd }}
     - spirv-tools 2026.1
-    - llvmdev 15
+    - llvmdev {{ libllvm20 }}
     - libxcb {{ libxcb }}             # [linux]
     - libdrm {{ libdrm }}             # [linux]
     - libglvnd-devel {{ libglvnd }}     # [linux]


### PR DESCRIPTION
mesalib 25.1.5

**Destination channel:**  defaults

### Links

- [PKG-14632](https://anaconda.atlassian.net/browse/PKG-14632) 
- [Upstream repository](https://gitlab.freedesktop.org/mesa/mesa)

### Explanation of changes:
- New build number
- Update llvmdev to newer version (with libxml2 2.14)


[PKG-14632]: https://anaconda.atlassian.net/browse/PKG-14632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ